### PR TITLE
Use assertSetEqual for set comparisons

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,8 +98,8 @@ class TestWordle(unittest.TestCase):
         self.wordle.answer = "knoll"
 
         self.assertTrue(self.wordle.update_score("boomy", "bbgbb"))
-        self.assertSequenceEqual(self.wordle.not_found_chars, {"m", "y", "b"})
-        self.assertSequenceEqual(self.wordle.found_chars, {"o"})
+        self.assertSetEqual(self.wordle.not_found_chars, {"m", "y", "b"})
+        self.assertSetEqual(self.wordle.found_chars, {"o"})
 
     def test_remove_invalid_words(self):
         self.wordle.found_chars = []


### PR DESCRIPTION
## Summary
- Replace `assertSequenceEqual` with `assertSetEqual` in tests covering double-letter guesses

## Testing
- `python -m unittest tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68969945ca7083238839c1c3d069ed9c