### PR TITLE
Fix typo in update_score docstring

### DIFF
--- a/wordle.py
+++ b/wordle.py
@@ -135,7 +135,7 @@ class Wordle:
         Track letters that are found and their positions
         @word_guess: Last word guessed
         @word_score: Score given by Wordle in color coded format, [G]reen, [Y]ellow, [B]lack
-        return: bool of sucess
+        return: bool of success
         """
 
         found_chars = set()


### PR DESCRIPTION
## Summary
- fix spelling error in update_score docstring

## Testing
- `python -m flake8 wordle.py` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6896992691c08323ad3b6f374bb89a83